### PR TITLE
Issue #3 | Removed command attribute from manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,4 +2,3 @@ applications:
   - name: k2dark
     buildpack: python_buildpack
     memory: 256M
-command: gunicorn manage:app


### PR DESCRIPTION
Removed redundant **command** specification from manifest.yml

This Predix Forum answer has the best explanation:
https://forum.predix.io/questions/2778/how-do-i-deploy-python-application-in-predix.html

tl;dr
You only need one. If you have both, the manifest.yml command properties will override the properties in the Procfile. Procfile seems to be more flexible and has more fault tolerance.